### PR TITLE
OTP Internal Version and Cloudwatch automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,80 @@
 
 This project contains a docker recipe for deploying an Ubuntu instance with OpenTripPlanner installed. Additionaly it contains configuration to deploy the container to AWS Elastic Beanstalk.
 
-## To deploy the container to AWS EB
-1. Install AWS EB CLI ```pip install awsebcli```
-1. cd docker
-2. eb init
-3. eb create
-5. eb deploy
+
+## Requirements
+
+In order to use this repository, you need to have the `AWS CLI` and `EB CLI`
+installed.
+If you want to test the images locally, you also must install `docker`:
+
+```
+$ brew install awscli aws-elasticbeanstalk
+```
+
+## Deploy the container to AWS EB
+
+Open up the directory `docker` in your favourite text editor and change
+the following files according to your needs:
+
+* `docker/Dockerfile`: Change the OTP download url if needed and adapt the
+  changes to the version number of the downloaded file.
+* `docker/run.sh` Change the version number of otp and also change the
+  memory needed to run OTP for the region you want to deploy
+
+You should now change your working directory to `./docker`:
+
+```
+$ cd docker
+```
+
+To deploy a new OTP instance either create a new `AWS EB Environment` or clone an existing
+one first.
+To see which environments are available, type `eb list`.
+
+### Cloning an environment:
+Select the desired environment to clone via `eb use <ENVIRONMENT-NAME` and then
+type `eb clone`.
+You will be asked about the name, cname and other things about your new environment.
+Finally the environment will be created.
+
+### Create a new environment:
+If you want to configure more things, create a new environment via `eb init` and
+`eb create <ENVIRONMENT-NAME>`.
+
+
+### Ready to deploy!
+
+Now that your environment is set up, you can deploy your docker container running
+OTP:
+
+```
+$ eb deploy --staged
+```
+
+The `--staged` option lets you upload a new application, without having to
+commit your local changes to the git repository.
+
+## Memory Monitoring:
+
+The new environment automatically sends instance performance values to AWS
+Cloudwatch (see the `.ebextensions` folder for more information on this).
+
+What is left is to create an actual alarm for AWS Cloudwatch.
+
+There are 3 small steps involved in this:
+
+1. Get the instance id of your instance: The command `eb status -v` prints the instance id to your console. You can copy it.
+
+2. Edit the file `alarm-skeleton.json`:
+   You should probably rename the alarm and enter the instance id in the corresponding
+   field.
+
+3. Create the alarm via your terminal: Now that the `alarm-skeleton.json` is prepared, you can create the alarm via
+
+   ```
+   aws cloudwatch put-metric-alarm --cli-input-json "$(less alarm-skeleton.json)"
+   ```
+
 
 

--- a/docker/.ebextensions/alarm.config
+++ b/docker/.ebextensions/alarm.config
@@ -1,0 +1,31 @@
+packages:
+  yum:
+    perl-DateTime: []
+    perl-Sys-Syslog: []
+    perl-LWP-Protocol-https: []
+    perl-Switch: []
+    perl-URI: []
+    perl-Bundle-LWP: []
+
+container_commands:
+  00download:
+    command: "wget http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip"
+    ignoreErrors: true
+  01extract:
+    command: "unzip CloudWatchMonitoringScripts-1.2.1.zip"
+    ignoreErrors: true
+  02rmzip:
+    command: "rm CloudWatchMonitoringScripts-1.2.1.zip"
+    ignoreErrors: true
+  03cdinto:
+    command: "mv aws-scripts-mon/ /home/ec2-user"
+    ignoreErrors: true
+  04croninstallblank:
+    command: "crontab -l | { cat; echo '* * * * * /home/ec2-user/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail'; } | crontab -"
+    ignoreErrors: false
+  05cronremove:
+    command: "crontab -r"
+    ignoreErrors: false
+  06cronreinstall:
+    command: "crontab -l | { cat; echo '* * * * * /home/ec2-user/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail'; } | crontab -"
+    ignoreErrors: false

--- a/docker/.ebextensions/nginx.config
+++ b/docker/.ebextensions/nginx.config
@@ -4,4 +4,6 @@ files:
         owner: root
         group: root
         content: |
-           client_max_body_size 1g;
+           client_max_body_size 4g;
+           proxy_send_timeout 300;
+           proxy_read_timeout 300;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,16 @@ RUN apt-get -qqy install zulu-8=8.9.0.4
 RUN apt-get install -y wget
 
 
+RUN echo "[Credentials]" > ~/.boto
+RUN echo "aws_access_key_id=$AWS_ACCESS_KEY_ID" >>  ~/.boto
+RUN echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >>  ~/.boto
+
+RUN curl https://gist.githubusercontent.com/shevron/6204349/raw/cw-monitor-memusage.py | sudo tee /usr/local/bin/cw-monitor-memusage.py
+
+RUN chmod +x /usr/local/bin/cw-monitor-memusage.py
+RUN echo "* * * * * ec2-user /usr/local/bin/cw-monitor-memusage.py" | sudo tee /etc/cron.d/cw-monitor-memusage
+
+
 #OTP
 RUN mkdir /otp
 WORKDIR /otp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get install -y wget
 #OTP
 RUN mkdir /otp
 WORKDIR /otp
-RUN wget https://s3.eu-central-1.amazonaws.com/d2d-otp/otp-0.20.0-SNAPSHOT.jar
+RUN wget -O otp-0.19.0.jar https://s3.eu-central-1.amazonaws.com/d2d-otp/otp-0.19.0.jar
 
 ADD run.sh /run.sh
 RUN chmod +x /*.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,17 +7,6 @@ RUN apt-get -qq update
 RUN apt-get -qqy install zulu-8=8.9.0.4
 RUN apt-get install -y wget
 
-
-RUN echo "[Credentials]" > ~/.boto
-RUN echo "aws_access_key_id=$AWS_ACCESS_KEY_ID" >>  ~/.boto
-RUN echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >>  ~/.boto
-
-RUN curl https://gist.githubusercontent.com/shevron/6204349/raw/cw-monitor-memusage.py | sudo tee /usr/local/bin/cw-monitor-memusage.py
-
-RUN chmod +x /usr/local/bin/cw-monitor-memusage.py
-RUN echo "* * * * * ec2-user /usr/local/bin/cw-monitor-memusage.py" | sudo tee /etc/cron.d/cw-monitor-memusage
-
-
 #OTP
 RUN mkdir /otp
 WORKDIR /otp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y wget
 #OTP
 RUN mkdir /otp
 WORKDIR /otp
-RUN wget -O otp-0.19.0.jar https://s3.eu-central-1.amazonaws.com/d2d-otp/otp-0.19.0.jar
+RUN wget -O otp-0.20.1-ROUTERCONFIG.jar https://s3.eu-central-1.amazonaws.com/d2d-otp/otp-0.20.1-ROUTERCONFIG.jar
 
 ADD run.sh /run.sh
 RUN chmod +x /*.sh

--- a/docker/alarm-skeleton.json
+++ b/docker/alarm-skeleton.json
@@ -1,0 +1,22 @@
+{
+    "AlarmName": "OTP-Region-Name Memory Usage High",
+    "AlarmDescription": "Memory Usage >= 90%",
+    "ActionsEnabled": true,
+    "AlarmActions": [
+        "arn:aws:sns:eu-central-1:361548929584:GIS-TEAM"
+    ],
+    "MetricName": "MemoryUtilization",
+    "Namespace": "System/Linux",
+    "Statistic": "Average",
+    "Dimensions": [
+        {
+            "Name": "InstanceId",
+            "Value": "i-d335e56e"
+        }
+    ],
+    "Period": 300,
+    "Unit": "Percent",
+    "EvaluationPeriods": 1,
+    "Threshold": 90.0,
+    "ComparisonOperator": "GreaterThanOrEqualToThreshold"
+}

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-java -Xmx7G -jar otp-0.20.0-SNAPSHOT.jar --server --insecure
+java -Xmx7G -jar otp-0.19.0.jar --server --insecure
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-java -Xmx7G -jar otp-0.19.0.jar --server --insecure
+java -Xmx8G -jar otp-0.19.0.jar --server --insecure
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-java -Xmx8G -jar otp-0.19.0.jar --server --insecure
+java -Xmx8G -jar otp-0.20.1-ROUTERCONFIG.jar --server --insecure
 


### PR DESCRIPTION
This PR uses a newer OTP Version (with embedded router config and a better routing heuristics) for
the docker container.

In addition the memory monitoring is automatically included in a cronjob for the deployed instance and
instructions are added to create the alarm via the command line
