### PR TITLE
added configurable logging

### DIFF
--- a/docker/logback.xml
+++ b/docker/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.opentripplanner.updater" level="OFF" />
+  <logger name="org.opentripplanner.routing.edgetype.Timetable" level="OFF" />
+  <logger name="org.opentripplanner.routing.trippattern.TripTimes" level="OFF" />
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-java -Xmx8G -jar otp-0.20.1-ROUTERCONFIG.jar --server --insecure
+java -Dlogback.configurationFile=/otp/logback.xml -Xmx7G -jar otp-0.20.1-ROUTERCONFIG.jar --server --insecure
 


### PR DESCRIPTION
- add a `logback.xml` configuration file to have a granular control of logging in OTP
- the configuration file can be passed to Java/OTP via command line params

All TripUpdate information will be filtered and the default log level is increased from `INFO` to `WARN`.
